### PR TITLE
fix: force h3 v1.x for Vercel compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,10 @@
     "vitest-package-exports": "catalog:test",
     "vue": "catalog:nuxt",
     "yaml": "catalog:"
+  },
+  "pnpm": {
+    "overrides": {
+      "h3": "^1.15.4"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ catalogs:
       specifier: ^22.0.0
       version: 22.19.3
 
+overrides:
+  h3: ^1.15.4
+
 importers:
 
   .:
@@ -6355,7 +6358,7 @@ packages:
   nuxt-site-config@3.2.14:
     resolution: {integrity: sha512-/IzAkBFpe8kDJiSK7fw7G0EPnNImIh0x4jdwil8Mmaz03usTtkeWgnfZu9NJpMSI9eO5jJ+dxd/avjxssvdqwQ==}
     peerDependencies:
-      h3: '>=1'
+      h3: ^1.15.4
 
   nuxt@4.2.2:
     resolution: {integrity: sha512-n6oYFikgLEb70J4+K19jAzfx4exZcRSRX7yZn09P5qlf2Z59VNOBqNmaZO5ObzvyGUZ308SZfL629/Q2v2FVjw==}


### PR DESCRIPTION
Fixes Vercel deployment error `TypeError: event.req.headers.get is not a function`

**Root cause:** `docus@5.4.1` → `nuxt-site-config@3.2.14` → `h3@2.0.1-rc.7` (pre-release)
- h3 v2 assumes Headers object with `.get()` method
- Vercel Node.js runtime provides plain object

**Fix:** pnpm override forces h3 v1.15.4 (stable) which uses `getHeader()` compatible with both

**Verified:**
- ✓ Local dev: `pnpm --filter docs dev` works
- ✓ h3 version: all deps use v1.15.4
- ✓ Vercel deployment: builds successfully, no runtime errors