### PR TITLE
fix: move pnpm overrides to workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,5 @@
     "vitest-package-exports": "catalog:test",
     "vue": "catalog:nuxt",
     "yaml": "catalog:"
-  },
-  "pnpm": {
-    "overrides": {
-      "h3": "^1.15.4"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - playground
   - docs
 
+overrides:
+  h3: ^1.15.4
 catalog:
   '@nuxt/content': ^3.10.0
   '@nuxt/fonts': ^0.12.1


### PR DESCRIPTION
Fixes CI lint failure from #2

**Issue:** eslint rule `pnpm/json-prefer-workspace-settings` requires pnpm settings in `pnpm-workspace.yaml`

**Fix:** moved `overrides.h3` from `package.json` to `pnpm-workspace.yaml`

**Verified:**
- ✓ `pnpm lint` passes
- ✓ h3 override still applied correctly