### PR TITLE
fix: use pnpm publish to resolve catalog refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: pnpm publish --provenance --access public


### PR DESCRIPTION
Closes #5

## Summary

npm doesn't understand `catalog:` protocol. Changed to pnpm publish which resolves catalog references to actual versions before publishing.

**Before**: `"@nuxt/kit": "catalog:prod"` published to npm  
**After**: `"@nuxt/kit": "^4.0.0"` published to npm