### PR TITLE
fix: use pnpm publish with --no-git-checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: pnpm publish --no-git-checks --provenance --access public


### PR DESCRIPTION
Closes #8

## Summary
`npm publish` doesn't resolve pnpm catalog references. Previous fix used `pnpm publish` but it failed due to git-checks. This uses `--no-git-checks` to skip that while still resolving catalogs.

## History
- `041fc95` - switched to `pnpm publish` (fixed catalogs, broke git-checks)
- `0521719` - reverted to `npm publish` (fixed git-checks, broke catalogs)
- This PR - `pnpm publish --no-git-checks` (fixes both)