### PR TITLE
feat(playground): add tabbed demos for all module features

### DIFF
--- a/playground/.nuxtrc
+++ b/playground/.nuxtrc
@@ -1,1 +1,1 @@
-setups.nuxt-convex="0.0.1"
+setups.nuxt-convex="0.0.6"

--- a/playground/app/components/AppHeader.vue
+++ b/playground/app/components/AppHeader.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+defineProps<{ showUser?: boolean }>()
+
+const { user, signOut } = useUserSession()
+</script>
+
+<template>
+  <header class="flex items-center justify-between px-6 py-4">
+    <div class="flex items-center gap-4">
+      <a href="https://nuxt.com" target="_blank" class="flex items-center gap-1.5 text-muted hover:text-nuxt">
+        <UIcon name="i-simple-icons-nuxtdotjs" class="size-5" />
+        <span class="text-sm font-medium hidden sm:block">Nuxt</span>
+      </a>
+      <a href="https://convex.dev" target="_blank" class="flex items-center gap-1.5 text-muted hover:text-convex">
+        <UIcon name="i-custom-convex" class="size-4" />
+        <span class="text-sm font-medium hidden sm:block">Convex</span>
+      </a>
+      <template v-if="showUser">
+        <USeparator orientation="vertical" class="h-5" />
+        <UBadge color="success" variant="subtle">
+          <span class="size-1.5 rounded-full bg-success animate-pulse mr-1.5" />
+          Connected
+        </UBadge>
+      </template>
+    </div>
+    <div class="flex items-center gap-3">
+      <UButton to="https://nuxt-convex.onmax.me" target="_blank" variant="ghost" color="neutral" size="sm">
+        Docs
+      </UButton>
+      <UButton to="https://github.com/onmax/nuxt-convex" target="_blank" icon="i-simple-icons-github" variant="ghost" color="neutral" size="sm" />
+      <UColorModeButton />
+      <template v-if="showUser && user">
+        <USeparator orientation="vertical" class="h-6" />
+        <UAvatar :src="user.image" :alt="user.name" size="sm" />
+        <span class="text-sm text-muted hidden sm:block">{{ user.name }}</span>
+        <UButton size="sm" variant="ghost" color="neutral" icon="i-heroicons-arrow-right-on-rectangle" @click="signOut()">
+          <span class="sr-only sm:not-sr-only">Sign out</span>
+        </UButton>
+      </template>
+    </div>
+  </header>
+</template>

--- a/playground/app/components/demos/ActionsDemo.vue
+++ b/playground/app/components/demos/ActionsDemo.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { api } from '#convex/api'
+
+const message = ref('Hello, Convex!')
+const delay = ref(1000)
+const result = ref<string | null>(null)
+
+const { mutate: runEcho, isLoading, error } = useConvexAction(api.actions.echo, {
+  onSuccess: (data) => {
+    result.value = data
+    useToast().add({ title: 'Action completed', description: data, color: 'success' })
+  },
+  onError: (err) => {
+    useToast().add({ title: 'Action failed', description: err.message, color: 'error' })
+  },
+})
+
+async function handleRun() {
+  result.value = null
+  await runEcho({ message: message.value, delay: delay.value })
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Basic Action -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-bolt" class="text-primary" />
+          <span class="font-semibold">useConvexAction</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Actions run server-side code that can call external APIs, have side effects, or perform long-running operations.
+      </div>
+
+      <div class="space-y-4">
+        <UInput v-model="message" placeholder="Message to echo..." />
+
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-muted">Delay:</span>
+          <UInput v-model.number="delay" type="number" :min="0" :max="5000" :step="500" class="w-32" />
+          <span class="text-xs text-muted">ms</span>
+        </div>
+
+        <UButton :loading="isLoading" :disabled="!message.trim()" @click="handleRun">
+          Run Echo Action
+        </UButton>
+      </div>
+    </UCard>
+
+    <!-- Loading State -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-clock" class="text-warning" />
+          <span class="font-semibold">Long-running Operations</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Actions expose <code class="bg-muted px-1 rounded">isLoading</code> for UI feedback during execution.
+      </div>
+
+      <div class="flex items-center gap-4">
+        <span class="text-sm text-muted">isLoading:</span>
+        <UBadge :color="isLoading ? 'warning' : 'neutral'" variant="subtle">
+          {{ isLoading }}
+        </UBadge>
+        <div v-if="isLoading" class="flex items-center gap-2 text-muted">
+          <UIcon name="i-heroicons-arrow-path" class="animate-spin" />
+          <span class="text-sm">Running action...</span>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Result -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-check-circle" class="text-success" />
+          <span class="font-semibold">Action Result</span>
+        </div>
+      </template>
+
+      <div v-if="result" class="p-4 rounded bg-success/10 border border-success/20">
+        <p class="font-mono text-sm">
+          {{ result }}
+        </p>
+      </div>
+      <div v-else class="text-sm text-muted">
+        Run an action to see the result here.
+      </div>
+
+      <UAlert v-if="error" color="error" :title="error.message" class="mt-4" />
+    </UCard>
+
+    <!-- Use Cases -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-light-bulb" class="text-info" />
+          <span class="font-semibold">Action Use Cases</span>
+        </div>
+      </template>
+
+      <ul class="text-sm text-muted space-y-2">
+        <li class="flex items-start gap-2">
+          <UIcon name="i-heroicons-check" class="text-success mt-0.5 shrink-0" />
+          <span>Calling external APIs (payment processors, email services)</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <UIcon name="i-heroicons-check" class="text-success mt-0.5 shrink-0" />
+          <span>Running computationally expensive operations</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <UIcon name="i-heroicons-check" class="text-success mt-0.5 shrink-0" />
+          <span>Orchestrating multiple mutations</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <UIcon name="i-heroicons-check" class="text-success mt-0.5 shrink-0" />
+          <span>Generating AI responses or processing media</span>
+        </li>
+      </ul>
+    </UCard>
+  </div>
+</template>

--- a/playground/app/components/demos/MutationsDemo.vue
+++ b/playground/app/components/demos/MutationsDemo.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import type { Doc, Id } from '../../../convex/_generated/dataModel'
+import { api } from '#convex/api'
+
+const toast = useToast()
+const { user } = useUserSession()
+const userId = computed(() => user.value?.id || '')
+
+const newTaskTitle = ref('')
+
+// Basic mutation
+const { mutate: addTask, isLoading: isAdding, error: addError } = useConvexMutation(api.tasks.add, {
+  onSuccess: () => {
+    newTaskTitle.value = ''
+    toast.add({ title: 'Task added', color: 'success' })
+  },
+  onError: (err) => {
+    toast.add({ title: 'Failed to add task', description: err.message, color: 'error' })
+  },
+})
+
+// Query for list
+const { data: tasks } = await useConvexQuery(api.tasks.list, computed(() => ({ userId: userId.value })))
+
+// Delete mutation
+const { mutate: deleteTask, isLoading: isDeleting } = useConvexMutation(api.tasks.remove)
+
+async function handleAdd() {
+  if (!newTaskTitle.value.trim())
+    return
+  await addTask({ title: newTaskTitle.value, userId: userId.value })
+}
+
+async function handleDelete(id: Id<'tasks'>) {
+  await deleteTask({ id })
+}
+
+// Mutation with optimistic update
+const { mutate: addOptimistic, isLoading: isAddingOptimistic } = useConvexMutation(api.tasks.add, {
+  optimisticUpdate: (localStore, args) => {
+    const current = localStore.getQuery(api.tasks.list, { userId: args.userId })
+    if (current) {
+      const tempTask: Doc<'tasks'> = { _id: `temp-${Date.now()}` as Id<'tasks'>, _creationTime: Date.now(), title: args.title, userId: args.userId, createdAt: Date.now() }
+      localStore.setQuery(api.tasks.list, { userId: args.userId }, [tempTask, ...current])
+    }
+  },
+  onSuccess: () => {
+    toast.add({ title: 'Task added (optimistic)', color: 'success' })
+  },
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Basic Mutation -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-pencil-square" class="text-primary" />
+          <span class="font-semibold">useConvexMutation (Basic)</span>
+        </div>
+      </template>
+
+      <form class="flex gap-2 mb-4" @submit.prevent="handleAdd">
+        <UInput v-model="newTaskTitle" placeholder="New task title..." class="flex-1" />
+        <UButton type="submit" :loading="isAdding" :disabled="!newTaskTitle.trim()">
+          Add Task
+        </UButton>
+      </form>
+
+      <UAlert v-if="addError" color="error" :title="addError.message" class="mb-4" />
+
+      <div class="space-y-2">
+        <div v-for="task in tasks?.slice(0, 5)" :key="task._id" class="group flex items-center justify-between p-2 rounded bg-muted">
+          <span class="text-sm">{{ task.title }}</span>
+          <UButton icon="i-heroicons-trash" size="xs" color="error" variant="ghost" :loading="isDeleting" class="opacity-0 group-hover:opacity-100" @click="handleDelete(task._id)" />
+        </div>
+        <div v-if="tasks && tasks.length > 5" class="text-xs text-muted">
+          ... and {{ tasks.length - 5 }} more
+        </div>
+        <UEmpty v-if="!tasks?.length" icon="i-heroicons-clipboard" title="No tasks" description="Add one above" class="py-4" />
+      </div>
+    </UCard>
+
+    <!-- Loading/Error States -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-exclamation-triangle" class="text-warning" />
+          <span class="font-semibold">isLoading & error States</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Mutations expose <code class="bg-muted px-1 rounded">isLoading</code> and <code class="bg-muted px-1 rounded">error</code> refs for UI feedback.
+      </div>
+
+      <div class="flex gap-4 text-sm">
+        <div class="flex items-center gap-2">
+          <span class="text-muted">isAdding:</span>
+          <UBadge :color="isAdding ? 'warning' : 'neutral'" variant="subtle">
+            {{ isAdding }}
+          </UBadge>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="text-muted">isDeleting:</span>
+          <UBadge :color="isDeleting ? 'warning' : 'neutral'" variant="subtle">
+            {{ isDeleting }}
+          </UBadge>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Optimistic Updates -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-bolt" class="text-success" />
+          <span class="font-semibold">Optimistic Updates</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Update UI immediately before server confirms. If mutation fails, changes roll back automatically.
+      </div>
+
+      <UButton :loading="isAddingOptimistic" @click="addOptimistic({ title: `Optimistic task ${Date.now()}`, userId })">
+        Add with Optimistic Update
+      </UButton>
+    </UCard>
+
+    <!-- Return Values -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-arrow-uturn-left" class="text-info" />
+          <span class="font-semibold">Return Value Handling</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted">
+        <code class="bg-muted px-1 rounded">mutate()</code> returns a Promise with the mutation result. Use <code class="bg-muted px-1 rounded">onSuccess</code> callback or <code class="bg-muted px-1 rounded">await mutate()</code> to handle return values.
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/playground/app/components/demos/PaginationDemo.vue
+++ b/playground/app/components/demos/PaginationDemo.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import type { Id } from '../../../convex/_generated/dataModel'
+import { api } from '#convex/api'
+
+const toast = useToast()
+const { user } = useUserSession()
+const userId = computed(() => user.value?.id || '')
+
+// Paginated query composable
+const { data, pages, isDone, isLoadingMore, loadMore, reset, isLoading } = useConvexPaginatedQuery(
+  api.tasks.listPaginated,
+  computed(() => ({ userId: userId.value })),
+  { numItems: 5 },
+)
+
+// Seed mutation for demo
+const { mutate: seedTasks, isLoading: isSeeding } = useConvexMutation(api.tasks.seed, {
+  onSuccess: (count) => {
+    toast.add({ title: `Created ${count} sample tasks`, color: 'success' })
+    reset()
+  },
+})
+
+// Delete all for cleanup
+const { mutate: deleteTask } = useConvexMutation(api.tasks.remove)
+const isClearing = ref(false)
+
+async function clearAll() {
+  if (!data.value?.length)
+    return
+  isClearing.value = true
+  try {
+    await Promise.all(data.value.map(task => deleteTask({ id: task._id as Id<'tasks'> })))
+  }
+  finally {
+    isClearing.value = false
+    reset()
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Composable Demo -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <UIcon name="i-heroicons-list-bullet" class="text-primary" />
+            <span class="font-semibold">useConvexPaginatedQuery</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <UButton size="xs" variant="outline" :loading="isSeeding" @click="seedTasks({ userId, count: 25 })">
+              Seed 25 Tasks
+            </UButton>
+            <UButton size="xs" variant="outline" color="error" :loading="isClearing" :disabled="!data?.length" @click="clearAll">
+              Clear All
+            </UButton>
+          </div>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Load data in pages with <code class="bg-muted px-1 rounded">loadMore()</code>. Great for infinite scroll.
+      </div>
+
+      <div v-if="isLoading && !data?.length" class="flex items-center gap-2 text-muted py-4">
+        <UIcon name="i-heroicons-arrow-path" class="animate-spin" />
+        Loading first page...
+      </div>
+
+      <div v-else-if="data?.length" class="space-y-4">
+        <div class="space-y-2">
+          <div v-for="task in data" :key="task._id" class="p-2 rounded bg-muted text-sm">
+            {{ task.title }}
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between pt-2 border-t border-default">
+          <div class="text-xs text-muted">
+            Showing {{ data.length }} items across {{ pages.length }} page(s)
+          </div>
+          <UButton v-if="!isDone" size="sm" :loading="isLoadingMore" @click="loadMore">
+            Load More
+          </UButton>
+          <UBadge v-else color="success" variant="subtle">
+            All loaded
+          </UBadge>
+        </div>
+      </div>
+
+      <UEmpty v-else icon="i-heroicons-list-bullet" title="No tasks" description="Click 'Seed 25 Tasks' to populate data" class="py-6" />
+    </UCard>
+
+    <!-- State Indicators -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-signal" class="text-info" />
+          <span class="font-semibold">Pagination State</span>
+        </div>
+      </template>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">isLoading</span>
+          <UBadge :color="isLoading ? 'warning' : 'neutral'" variant="subtle">
+            {{ isLoading }}
+          </UBadge>
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">isLoadingMore</span>
+          <UBadge :color="isLoadingMore ? 'warning' : 'neutral'" variant="subtle">
+            {{ isLoadingMore }}
+          </UBadge>
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">isDone</span>
+          <UBadge :color="isDone ? 'success' : 'neutral'" variant="subtle">
+            {{ isDone }}
+          </UBadge>
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">pages.length</span>
+          <UBadge color="neutral" variant="subtle">
+            {{ pages.length }}
+          </UBadge>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Component Demo -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-code-bracket" class="text-warning" />
+          <span class="font-semibold">&lt;ConvexPaginatedQuery&gt; Component</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Renderless component with slots for all states and pagination controls in slot props.
+      </div>
+
+      <ConvexPaginatedQuery :query="api.tasks.listPaginated" :args="{ userId }" :options="{ numItems: 3 }">
+        <template #loading>
+          <div class="flex items-center gap-2 text-muted py-4">
+            <UIcon name="i-heroicons-arrow-path" class="animate-spin" />
+            Loading...
+          </div>
+        </template>
+        <template #error="{ error, reset: resetError }">
+          <UAlert color="error" :title="error.message">
+            <template #actions>
+              <UButton size="xs" @click="resetError">
+                Retry
+              </UButton>
+            </template>
+          </UAlert>
+        </template>
+        <template #empty>
+          <UEmpty icon="i-heroicons-list-bullet" title="No tasks" class="py-4" />
+        </template>
+        <template #default="{ data: items, isDone: done, isLoadingMore: loadingMore, loadMore: more }">
+          <div class="space-y-2">
+            <div v-for="task in items.slice(0, 5)" :key="task._id" class="p-2 rounded bg-muted text-sm">
+              {{ task.title }}
+            </div>
+            <div v-if="items.length > 5" class="text-xs text-muted">
+              ... and {{ items.length - 5 }} more
+            </div>
+            <UButton v-if="!done" size="sm" :loading="loadingMore" class="mt-2" @click="more">
+              Load More (Component)
+            </UButton>
+          </div>
+        </template>
+      </ConvexPaginatedQuery>
+    </UCard>
+
+    <!-- Reset -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-arrow-path" class="text-secondary" />
+          <span class="font-semibold">reset() Function</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Call <code class="bg-muted px-1 rounded">reset()</code> to clear all pages and start fresh from page 1.
+      </div>
+
+      <UButton variant="outline" @click="reset">
+        Reset Pagination
+      </UButton>
+    </UCard>
+  </div>
+</template>

--- a/playground/app/components/demos/QueriesDemo.vue
+++ b/playground/app/components/demos/QueriesDemo.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { api } from '#convex/api'
+
+const { user } = useUserSession()
+const userId = computed(() => user.value?.id || '')
+
+// SSR-enabled query (default)
+const { data: tasksSSR, pending: pendingSSR } = await useConvexQuery(api.tasks.list, computed(() => ({ userId: userId.value })))
+
+// Client-only query (ssr: false)
+const { data: tasksClient, pending: pendingClient } = await useConvexQuery(api.tasks.list, computed(() => ({ userId: userId.value })), { ssr: false })
+
+// Reactive args demo - showCompleted is used in UI to demonstrate computed() args pattern
+const showCompleted = ref(false)
+const filterArgs = computed(() => ({ userId: userId.value }))
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- SSR Query -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-server" class="text-primary" />
+          <span class="font-semibold">useConvexQuery (SSR enabled)</span>
+          <UBadge color="success" variant="subtle" size="xs">
+            Default
+          </UBadge>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-3">
+        Data fetched on server and hydrated. Check "view source" to see pre-rendered content.
+      </div>
+
+      <div v-if="pendingSSR" class="flex items-center gap-2 text-muted">
+        <UIcon name="i-heroicons-arrow-path" class="animate-spin" />
+        Loading...
+      </div>
+      <div v-else-if="tasksSSR?.length" class="space-y-2">
+        <div v-for="task in tasksSSR.slice(0, 3)" :key="task._id" class="p-2 rounded bg-muted text-sm">
+          {{ task.title }}
+        </div>
+        <div v-if="tasksSSR.length > 3" class="text-xs text-muted">
+          ... and {{ tasksSSR.length - 3 }} more
+        </div>
+      </div>
+      <UEmpty v-else icon="i-heroicons-clipboard" title="No tasks" description="Add some tasks in the Mutations tab" class="py-4" />
+    </UCard>
+
+    <!-- Client-only Query -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-computer-desktop" class="text-secondary" />
+          <span class="font-semibold">useConvexQuery (ssr: false)</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-3">
+        Data fetched only on client. Useful for user-specific data that shouldn't be SSR'd.
+      </div>
+
+      <div v-if="pendingClient" class="flex items-center gap-2 text-muted">
+        <UIcon name="i-heroicons-arrow-path" class="animate-spin" />
+        Loading...
+      </div>
+      <div v-else-if="tasksClient?.length" class="text-sm text-muted">
+        {{ tasksClient.length }} tasks loaded client-side
+      </div>
+      <UEmpty v-else icon="i-heroicons-clipboard" title="No tasks" class="py-4" />
+    </UCard>
+
+    <!-- ConvexQuery Component -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-code-bracket" class="text-warning" />
+          <span class="font-semibold">&lt;ConvexQuery&gt; Component</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-3">
+        Renderless component with slots for loading, error, empty, and default states.
+      </div>
+
+      <ConvexQuery :query="api.tasks.list" :args="filterArgs">
+        <template #loading>
+          <div class="flex items-center gap-2 text-muted py-4">
+            <UIcon name="i-heroicons-arrow-path" class="animate-spin" />
+            Loading via component...
+          </div>
+        </template>
+        <template #error="{ error }">
+          <UAlert color="error" :title="error.message" />
+        </template>
+        <template #empty>
+          <UEmpty icon="i-heroicons-clipboard" title="No tasks" class="py-4" />
+        </template>
+        <template #default="{ data }">
+          <div class="space-y-2">
+            <div v-for="task in data.slice(0, 3)" :key="task._id" class="p-2 rounded bg-muted text-sm">
+              {{ task.title }}
+            </div>
+            <div v-if="data.length > 3" class="text-xs text-muted">
+              ... and {{ data.length - 3 }} more
+            </div>
+          </div>
+        </template>
+      </ConvexQuery>
+    </UCard>
+
+    <!-- Reactive Args -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-arrow-path" class="text-info" />
+          <span class="font-semibold">Reactive Arguments</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-3">
+        Use <code class="bg-muted px-1 rounded">computed()</code> for args to automatically re-fetch when dependencies change.
+      </div>
+
+      <div class="flex items-center gap-4">
+        <USwitch v-model="showCompleted" />
+        <span class="text-sm">Toggle state: {{ showCompleted ? 'ON' : 'OFF' }}</span>
+      </div>
+      <p class="text-xs text-muted mt-2">
+        In a real app, this would filter tasks based on completed status.
+      </p>
+    </UCard>
+  </div>
+</template>

--- a/playground/app/components/demos/StorageDemo.vue
+++ b/playground/app/components/demos/StorageDemo.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+import { api } from '#convex/api'
+
+const toast = useToast()
+const { user } = useUserSession()
+const userId = computed(() => user.value?.id || '')
+
+const fileInput = ref<HTMLInputElement>()
+const selectedFile = ref<File | null>(null)
+
+// Upload composable
+const { upload, isUploading, progress, error: uploadError } = useConvexUpload({
+  generateUploadUrl: { mutate: async () => {
+    const convex = useConvex()
+    return await convex.mutation(api._hub.storage.generateUploadUrl, {})
+  } },
+  onSuccess: async (storageId, file) => {
+    const convex = useConvex()
+    await convex.mutation(api._hub.storage.saveFile, { storageId, name: file.name, type: file.type, userId: userId.value })
+    toast.add({ title: 'File uploaded', description: file.name, color: 'success' })
+    selectedFile.value = null
+  },
+  onError: (err) => {
+    toast.add({ title: 'Upload failed', description: err.message, color: 'error' })
+  },
+})
+
+// Query uploads
+const { data: uploads } = await useConvexQuery(api._hub.storage.list, computed(() => ({ userId: userId.value })))
+
+// Delete mutation
+const { mutate: deleteUpload } = useConvexMutation(api._hub.storage.remove)
+
+function handleFileSelect(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (file) {
+    selectedFile.value = file
+  }
+}
+
+async function handleUpload() {
+  if (selectedFile.value) {
+    await upload(selectedFile.value)
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Upload Demo -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-arrow-up-tray" class="text-primary" />
+          <span class="font-semibold">useConvexUpload</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        Upload files to Convex storage with progress tracking.
+      </div>
+
+      <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="handleFileSelect">
+
+      <div class="space-y-4">
+        <div class="flex gap-2">
+          <UButton variant="outline" icon="i-heroicons-folder-open" @click="fileInput?.click()">
+            Select File
+          </UButton>
+          <UButton :loading="isUploading" :disabled="!selectedFile" @click="handleUpload">
+            Upload
+          </UButton>
+        </div>
+
+        <div v-if="selectedFile" class="flex items-center gap-2 p-2 rounded bg-muted text-sm">
+          <UIcon name="i-heroicons-document" class="text-muted" />
+          {{ selectedFile.name }}
+          <span class="text-muted">({{ (selectedFile.size / 1024).toFixed(1) }} KB)</span>
+        </div>
+
+        <div v-if="isUploading" class="space-y-2">
+          <UProgress :value="progress" />
+          <p class="text-xs text-muted">
+            {{ progress }}% uploaded
+          </p>
+        </div>
+
+        <UAlert v-if="uploadError" color="error" :title="uploadError.message" />
+      </div>
+    </UCard>
+
+    <!-- Upload State -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-signal" class="text-info" />
+          <span class="font-semibold">Upload State</span>
+        </div>
+      </template>
+
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">isUploading</span>
+          <UBadge :color="isUploading ? 'warning' : 'neutral'" variant="subtle">
+            {{ isUploading }}
+          </UBadge>
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">progress</span>
+          <UBadge color="neutral" variant="subtle">
+            {{ progress }}%
+          </UBadge>
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-muted">error</span>
+          <UBadge :color="uploadError ? 'error' : 'neutral'" variant="subtle">
+            {{ uploadError?.message || 'null' }}
+          </UBadge>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Uploaded Files -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <UIcon name="i-heroicons-photo" class="text-secondary" />
+            <span class="font-semibold">Uploaded Files</span>
+          </div>
+          <UBadge v-if="uploads?.length" size="sm" color="neutral" variant="subtle">
+            {{ uploads.length }}
+          </UBadge>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted mb-4">
+        <code class="bg-muted px-1 rounded">useConvexStorage().getUrl()</code> returns reactive URLs.
+      </div>
+
+      <div v-if="uploads?.length" class="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div v-for="file in uploads" :key="file._id" class="group relative rounded-lg overflow-hidden border border-default">
+          <img v-if="file.type?.startsWith('image/')" :src="file.url" :alt="file.name" class="w-full h-24 object-cover">
+          <div v-else class="w-full h-24 bg-muted flex items-center justify-center">
+            <UIcon name="i-heroicons-document" class="size-8 text-muted" />
+          </div>
+          <div class="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 flex items-center justify-center transition-opacity">
+            <UButton icon="i-heroicons-trash" color="error" variant="ghost" size="sm" @click="deleteUpload({ id: file._id })" />
+          </div>
+          <p class="text-xs text-muted p-2 truncate">
+            {{ file.name }}
+          </p>
+        </div>
+      </div>
+      <UEmpty v-else icon="i-heroicons-photo" title="No uploads" description="Upload an image above" class="py-6" />
+    </UCard>
+
+    <!-- Reactive URLs -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-heroicons-link" class="text-warning" />
+          <span class="font-semibold">Reactive Storage URLs</span>
+        </div>
+      </template>
+
+      <div class="text-sm text-muted">
+        <code class="bg-muted px-1 rounded">storage.getUrl(storageId)</code> returns a <code class="bg-muted px-1 rounded">Ref&lt;string | null&gt;</code> that updates when the URL changes or expires.
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/playground/app/middleware/auth.ts
+++ b/playground/app/middleware/auth.ts
@@ -1,0 +1,6 @@
+// Redirects unauthenticated users to index
+export default defineNuxtRouteMiddleware(() => {
+  const { user } = useUserSession()
+  if (!user.value)
+    return navigateTo('/')
+})

--- a/playground/app/middleware/guest.ts
+++ b/playground/app/middleware/guest.ts
@@ -1,0 +1,6 @@
+// Redirects authenticated users to dashboard
+export default defineNuxtRouteMiddleware(() => {
+  const { user } = useUserSession()
+  if (user.value)
+    return navigateTo('/dashboard')
+})

--- a/playground/app/pages/dashboard.vue
+++ b/playground/app/pages/dashboard.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+const convexUrl = useRuntimeConfig().public.convex?.url as string | undefined
+
+type TabValue = 'queries' | 'mutations' | 'pagination' | 'storage' | 'actions'
+
+const tabs: Array<{ label: string, value: TabValue, icon: string }> = [
+  { label: 'Queries', value: 'queries', icon: 'i-heroicons-magnifying-glass' },
+  { label: 'Mutations', value: 'mutations', icon: 'i-heroicons-pencil-square' },
+  { label: 'Pagination', value: 'pagination', icon: 'i-heroicons-list-bullet' },
+  { label: 'Storage', value: 'storage', icon: 'i-heroicons-cloud-arrow-up' },
+  { label: 'Actions', value: 'actions', icon: 'i-heroicons-bolt' },
+]
+
+const demoComponents: Record<TabValue, ReturnType<typeof resolveComponent>> = {
+  queries: resolveComponent('DemosQueriesDemo'),
+  mutations: resolveComponent('DemosMutationsDemo'),
+  pagination: resolveComponent('DemosPaginationDemo'),
+  storage: resolveComponent('DemosStorageDemo'),
+  actions: resolveComponent('DemosActionsDemo'),
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-default">
+    <div class="max-w-5xl mx-auto px-6 py-8">
+      <AppHeader show-user class="mb-8" />
+
+      <ClientOnly>
+        <UTabs :items="tabs" class="w-full" default-value="queries">
+          <template #content="{ item }">
+            <div class="mt-6">
+              <component :is="demoComponents[item.value as TabValue]" />
+            </div>
+          </template>
+        </UTabs>
+
+        <template #fallback>
+          <div class="flex justify-center py-12">
+            <UIcon name="i-heroicons-arrow-path" class="size-8 animate-spin text-muted" />
+          </div>
+        </template>
+      </ClientOnly>
+
+      <p class="text-center text-xs text-dimmed mt-8">
+        Connected to <code class="text-muted">{{ convexUrl }}</code>
+      </p>
+    </div>
+  </div>
+</template>

--- a/playground/app/pages/index.vue
+++ b/playground/app/pages/index.vue
@@ -1,112 +1,7 @@
 <script setup lang="ts">
-import type { ConvexClient } from 'convex/browser'
+definePageMeta({ middleware: 'guest' })
 
-const config = useRuntimeConfig()
-const convexUrl = (config.public.convex as { url?: string })?.url
-
-// Auth
-const { user, signIn, signOut } = useUserSession()
-const userId = computed(() => user.value?.id || '')
-
-// Convex state
-const tasks = ref<any[]>([])
-const uploads = ref<any[]>([])
-const newTaskTitle = ref('')
-const isAdding = ref(false)
-const fileInput = ref<HTMLInputElement>()
-const isUploading = ref(false)
-const uploadError = ref<Error | null>(null)
-
-let convexClient: ConvexClient | null = null
-let api: any = null
-let uploadFn: ((file: File) => Promise<string | null>) | null = null
-let tasksUnsubscribe: (() => void) | null = null
-let uploadsUnsubscribe: (() => void) | null = null
-
-if (import.meta.client) {
-  const { useConvex } = await import('#convex')
-  convexClient = useConvex()
-  api = (await import('#convex/api')).api
-}
-
-function subscribeToData(uid: string) {
-  if (!convexClient || !api || !uid)
-    return
-  tasksUnsubscribe?.()
-  uploadsUnsubscribe?.()
-  tasksUnsubscribe = convexClient.onUpdate(api.tasks.list, { userId: uid }, (result) => {
-    tasks.value = result || []
-  })
-  uploadsUnsubscribe = convexClient.onUpdate(api._hub.storage.list, { userId: uid }, (result) => {
-    uploads.value = result || []
-  })
-}
-
-onMounted(() => {
-  if (!userId.value || !convexClient || !api)
-    return
-  subscribeToData(userId.value)
-  const uploader = useConvexUpload({
-    generateUploadUrl: { mutate: () => convexClient!.mutation(api._hub.storage.generateUploadUrl, {}) },
-    onSuccess: async (storageId, file) => {
-      await convexClient!.mutation(api._hub.storage.saveFile, { storageId, name: file.name, type: file.type, userId: userId.value })
-      useToast().add({ title: 'File uploaded', description: file.name, color: 'success' })
-    },
-    onError: (err) => {
-      useToast().add({ title: 'Upload failed', description: err.message, color: 'error' })
-    },
-  })
-  uploadFn = uploader.upload
-  watch(() => uploader.isUploading.value, v => isUploading.value = v)
-  watch(() => uploader.error.value, v => uploadError.value = v)
-})
-
-watch(userId, (newId) => {
-  if (!newId) {
-    tasks.value = []
-    uploads.value = []
-    tasksUnsubscribe?.()
-    uploadsUnsubscribe?.()
-    return
-  }
-  subscribeToData(newId)
-})
-
-onUnmounted(() => {
-  tasksUnsubscribe?.()
-  uploadsUnsubscribe?.()
-})
-
-async function addTask() {
-  if (!newTaskTitle.value.trim() || !convexClient || !api || !userId.value)
-    return
-  isAdding.value = true
-  try {
-    await convexClient.mutation(api.tasks.add, { title: newTaskTitle.value, userId: userId.value })
-    newTaskTitle.value = ''
-  }
-  finally {
-    isAdding.value = false
-  }
-}
-
-async function deleteTask(id: string) {
-  if (!convexClient || !api)
-    return
-  await convexClient.mutation(api.tasks.remove, { id })
-}
-
-async function handleFileUpload(event: Event) {
-  const file = (event.target as HTMLInputElement).files?.[0]
-  if (file && uploadFn)
-    await uploadFn(file)
-}
-
-async function deleteUpload(id: string) {
-  if (!convexClient || !api)
-    return
-  await convexClient.mutation(api._hub.storage.remove, { id })
-}
+const { signIn } = useUserSession()
 
 const features = [
   { icon: 'i-heroicons-bolt', title: 'Realtime', description: 'Live subscriptions sync data instantly across all clients' },
@@ -116,210 +11,46 @@ const features = [
 </script>
 
 <template>
-  <div class="min-h-screen bg-default">
-    <!-- Logged Out: Hero -->
-    <div v-if="!user" class="min-h-screen flex flex-col">
-      <!-- Header -->
-      <header class="flex items-center justify-between px-6 py-4">
-        <div class="flex items-center gap-4">
-          <a href="https://nuxt.com" target="_blank" class="flex items-center gap-1.5 text-muted hover:text-nuxt">
-            <UIcon name="i-simple-icons-nuxtdotjs" class="size-5" />
-            <span class="text-sm font-medium">Nuxt</span>
-          </a>
-          <a href="https://convex.dev" target="_blank" class="flex items-center gap-1.5 text-muted hover:text-convex">
-            <UIcon name="i-custom-convex" class="size-4" />
-            <span class="text-sm font-medium">Convex</span>
-          </a>
-        </div>
-        <div class="flex items-center gap-2">
-          <UButton to="https://nuxt-convex.onmax.me" target="_blank" variant="ghost" color="neutral" size="sm">
-            Docs
-          </UButton>
-          <UButton to="https://github.com/onmax/nuxt-convex" target="_blank" icon="i-simple-icons-github" variant="ghost" color="neutral" size="sm" />
-          <UColorModeButton />
-        </div>
-      </header>
+  <div class="min-h-screen flex flex-col bg-default">
+    <AppHeader />
 
-      <!-- Hero -->
-      <div class="flex-1 flex flex-col items-center justify-center px-6 py-12">
-        <div class="flex items-center gap-4 mb-8">
-          <UIcon name="i-simple-icons-nuxtdotjs" class="size-12 text-nuxt" />
-          <span class="text-2xl text-muted">+</span>
-          <UIcon name="i-custom-convex" class="size-10 text-convex" />
-        </div>
-
-        <h1 class="text-5xl sm:text-6xl font-bold text-highlighted mb-4 text-center">
-          nuxt-convex
-        </h1>
-        <p class="text-xl text-muted mb-10 text-center max-w-md">
-          Realtime data & file storage for Nuxt
-        </p>
-
-        <UButton size="xl" color="primary" icon="i-simple-icons-github" @click="signIn.social({ provider: 'github' })">
-          Continue with GitHub
-        </UButton>
-
-        <!-- Features -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-16 max-w-3xl w-full">
-          <UCard v-for="feature in features" :key="feature.title" class="text-center">
-            <div class="flex flex-col items-center gap-3">
-              <div class="size-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                <UIcon :name="feature.icon" class="size-5 text-primary" />
-              </div>
-              <h3 class="font-semibold text-highlighted">
-                {{ feature.title }}
-              </h3>
-              <p class="text-sm text-muted">
-                {{ feature.description }}
-              </p>
-            </div>
-          </UCard>
-        </div>
-
-        <p class="text-xs text-dimmed mt-16">
-          Demo data auto-deletes after 24h
-        </p>
+    <div class="flex-1 flex flex-col items-center justify-center px-6 py-12">
+      <div class="flex items-center gap-4 mb-8">
+        <UIcon name="i-simple-icons-nuxtdotjs" class="size-12 text-nuxt" />
+        <span class="text-2xl text-muted">+</span>
+        <UIcon name="i-custom-convex" class="size-10 text-convex" />
       </div>
-    </div>
 
-    <!-- Logged In: Dashboard -->
-    <div v-else class="max-w-5xl mx-auto px-6 py-8">
-      <!-- Header -->
-      <header class="flex items-center justify-between mb-8">
-        <div class="flex items-center gap-4">
-          <a href="https://nuxt.com" target="_blank" class="flex items-center gap-1.5 text-muted hover:text-nuxt">
-            <UIcon name="i-simple-icons-nuxtdotjs" class="size-5" />
-            <span class="text-sm font-medium hidden sm:block">Nuxt</span>
-          </a>
-          <a href="https://convex.dev" target="_blank" class="flex items-center gap-1.5 text-muted hover:text-convex">
-            <UIcon name="i-custom-convex" class="size-4" />
-            <span class="text-sm font-medium hidden sm:block">Convex</span>
-          </a>
-          <USeparator orientation="vertical" class="h-5" />
-          <UBadge color="success" variant="subtle">
-            <span class="size-1.5 rounded-full bg-success animate-pulse mr-1.5" />
-            Connected
-          </UBadge>
-        </div>
-        <div class="flex items-center gap-3">
-          <UButton to="https://nuxt-convex.onmax.me" target="_blank" variant="ghost" color="neutral" size="sm">
-            Docs
-          </UButton>
-          <UButton to="https://github.com/onmax/nuxt-convex" target="_blank" icon="i-simple-icons-github" variant="ghost" color="neutral" size="sm" />
-          <UColorModeButton />
-          <USeparator orientation="vertical" class="h-6" />
-          <UAvatar :src="user.image" :alt="user.name" size="sm" />
-          <span class="text-sm text-muted hidden sm:block">{{ user.name }}</span>
-          <UButton size="sm" variant="ghost" color="neutral" icon="i-heroicons-arrow-right-on-rectangle" @click="signOut()">
-            <span class="sr-only sm:not-sr-only">Sign out</span>
-          </UButton>
-        </div>
-      </header>
+      <h1 class="text-5xl sm:text-6xl font-bold text-highlighted mb-4 text-center">
+        nuxt-convex
+      </h1>
+      <p class="text-xl text-muted mb-10 text-center max-w-md">
+        Realtime data & file storage for Nuxt
+      </p>
 
-      <ClientOnly>
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <!-- Tasks -->
-          <UCard>
-            <template #header>
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-2">
-                  <UIcon name="i-heroicons-clipboard-document-list" class="text-primary" />
-                  <span class="font-semibold">Tasks</span>
-                </div>
-                <UBadge v-if="tasks.length" size="sm" color="neutral" variant="subtle">
-                  {{ tasks.length }}
-                </UBadge>
-              </div>
-            </template>
+      <UButton size="xl" color="primary" icon="i-simple-icons-github" @click="signIn.social({ provider: 'github' })">
+        Continue with GitHub
+      </UButton>
 
-            <form class="flex gap-2 mb-4" @submit.prevent="addTask">
-              <UInput v-model="newTaskTitle" placeholder="Add a task..." class="flex-1" />
-              <UButton type="submit" color="primary" :loading="isAdding" :disabled="!newTaskTitle.trim()">
-                Add
-              </UButton>
-            </form>
-
-            <div class="space-y-2">
-              <div
-                v-for="task in tasks"
-                :key="task._id"
-                class="group flex items-center justify-between p-3 rounded-lg bg-muted"
-              >
-                <span class="text-default">{{ task.title }}</span>
-                <UButton
-                  icon="i-heroicons-trash"
-                  size="xs"
-                  color="error"
-                  variant="ghost"
-                  class="opacity-0 group-hover:opacity-100"
-                  @click="deleteTask(task._id)"
-                />
-              </div>
-              <UEmpty v-if="!tasks.length" icon="i-heroicons-clipboard" title="No tasks yet" class="py-6" />
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-16 max-w-3xl w-full">
+        <UCard v-for="feature in features" :key="feature.title" class="text-center">
+          <div class="flex flex-col items-center gap-3">
+            <div class="size-10 rounded-lg bg-primary/10 flex items-center justify-center">
+              <UIcon :name="feature.icon" class="size-5 text-primary" />
             </div>
-          </UCard>
-
-          <!-- Uploads -->
-          <UCard>
-            <template #header>
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-2">
-                  <UIcon name="i-heroicons-photo" class="text-secondary" />
-                  <span class="font-semibold">Uploads</span>
-                </div>
-                <UBadge v-if="uploads.length" size="sm" color="neutral" variant="subtle">
-                  {{ uploads.length }}
-                </UBadge>
-              </div>
-            </template>
-
-            <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="handleFileUpload">
-            <UButton
-              :loading="isUploading"
-              color="primary"
-              icon="i-heroicons-arrow-up-tray"
-              variant="outline"
-              class="w-full mb-4"
-              @click="fileInput?.click()"
-            >
-              {{ isUploading ? 'Uploading...' : 'Upload Image' }}
-            </UButton>
-
-            <UAlert v-if="uploadError" color="error" :title="uploadError.message" class="mb-4" />
-
-            <div v-if="uploads.length" class="grid grid-cols-2 gap-3">
-              <div v-for="file in uploads" :key="file._id" class="group relative rounded-lg overflow-hidden">
-                <img
-                  v-if="file.type?.startsWith('image/')"
-                  :src="file.url"
-                  :alt="file.name"
-                  class="w-full h-24 object-cover"
-                >
-                <div v-else class="w-full h-24 bg-muted flex items-center justify-center">
-                  <UIcon name="i-heroicons-document" class="size-6 text-muted" />
-                </div>
-                <div class="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 flex items-center justify-center">
-                  <UButton icon="i-heroicons-trash" color="error" variant="ghost" size="sm" @click="deleteUpload(file._id)" />
-                </div>
-                <p class="text-xs text-muted mt-1 truncate">
-                  {{ file.name }}
-                </p>
-              </div>
-            </div>
-            <UEmpty v-else icon="i-heroicons-photo" title="No uploads yet" class="py-6" />
-          </UCard>
-        </div>
-
-        <p class="text-center text-xs text-dimmed mt-8">
-          Connected to <code class="text-muted">{{ convexUrl }}</code>
-        </p>
-
-        <template #fallback>
-          <div class="flex justify-center py-12">
-            <UIcon name="i-heroicons-arrow-path" class="size-8 animate-spin text-muted" />
+            <h3 class="font-semibold text-highlighted">
+              {{ feature.title }}
+            </h3>
+            <p class="text-sm text-muted">
+              {{ feature.description }}
+            </p>
           </div>
-        </template>
-      </ClientOnly>
+        </UCard>
+      </div>
+
+      <p class="text-xs text-dimmed mt-16">
+        Demo data auto-deletes after 24h
+      </p>
     </div>
   </div>
 </template>

--- a/playground/convex/actions.ts
+++ b/playground/convex/actions.ts
@@ -1,0 +1,10 @@
+import { v } from 'convex/values'
+import { action } from './_generated/server'
+
+export const echo = action({
+  args: { message: v.string(), delay: v.optional(v.number()) },
+  handler: async (_ctx, { message, delay = 1000 }) => {
+    await new Promise(r => setTimeout(r, delay))
+    return `Echo: ${message} (delayed ${delay}ms)`
+  },
+})

--- a/playground/convex/tasks.ts
+++ b/playground/convex/tasks.ts
@@ -1,3 +1,4 @@
+import { paginationOptsValidator } from 'convex/server'
 import { v } from 'convex/values'
 import { mutation, query } from './_generated/server'
 
@@ -5,6 +6,13 @@ export const list = query({
   args: { userId: v.string() },
   handler: async (ctx, { userId }) => {
     return await ctx.db.query('tasks').withIndex('by_user', q => q.eq('userId', userId)).order('desc').collect()
+  },
+})
+
+export const listPaginated = query({
+  args: { userId: v.string(), paginationOpts: paginationOptsValidator },
+  handler: async (ctx, { userId, paginationOpts }) => {
+    return await ctx.db.query('tasks').withIndex('by_user', q => q.eq('userId', userId)).order('desc').paginate(paginationOpts)
   },
 })
 
@@ -19,5 +27,15 @@ export const remove = mutation({
   args: { id: v.id('tasks') },
   handler: async (ctx, { id }) => {
     await ctx.db.delete(id)
+  },
+})
+
+export const seed = mutation({
+  args: { userId: v.string(), count: v.optional(v.number()) },
+  handler: async (ctx, { userId, count = 25 }) => {
+    for (let i = 0; i < count; i++) {
+      await ctx.db.insert('tasks', { title: `Sample task #${i + 1}`, userId, createdAt: Date.now() - i * 60000 })
+    }
+    return count
   },
 })

--- a/playground/package.json
+++ b/playground/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@nuxt/ui": "catalog:",
     "nuxt": "catalog:",
+    "tailwindcss": "catalog:",
     "wrangler": "catalog:playground"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       nuxt:
         specifier: 'catalog:'
         version: 4.2.2(@parcel/watcher@2.5.1)(@types/node@25.0.5)(@vue/compiler-sfc@3.5.26)(better-sqlite3@12.5.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.5.0))(eslint@9.39.2(jiti@2.6.1))(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rolldown@1.0.0-beta.53)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
       wrangler:
         specifier: catalog:playground
         version: 4.55.0(@cloudflare/workers-types@4.20251217.0)

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import type { ConvexConfig, ResolvedConvexConfig } from './types/config'
 import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import process from 'node:process'
-import { addImports, addPlugin, addTemplate, addTypeTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { addComponent, addImports, addPlugin, addTemplate, addTypeTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { consola } from 'consola'
 import { defu } from 'defu'
 import { join } from 'pathe'
@@ -84,6 +84,7 @@ export { getConvexClient as useConvex } from '${resolve('./runtime/client')}'
 export { useConvexMutation } from '${resolve('./runtime/composables/useConvexMutation')}'
 export { useConvexAction } from '${resolve('./runtime/composables/useConvexAction')}'
 export { useConvexQuery } from '${resolve('./runtime/composables/useConvexQuery')}'
+export { useConvexPaginatedQuery } from '@convex-vue/core'
 `,
     write: true,
   })
@@ -97,6 +98,8 @@ import type { AsyncData, AsyncDataOptions } from 'nuxt/app'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 
 declare module '#convex' {
+  export { useConvexPaginatedQuery } from '@convex-vue/core'
+
   export interface UseConvexMutationReturn<Mutation extends FunctionReference<'mutation'>> {
     isLoading: Ref<boolean>
     error: Ref<Error | null>
@@ -140,7 +143,12 @@ declare module '#convex' {
     { name: 'useConvexMutation', from: '#convex' },
     { name: 'useConvexAction', from: '#convex' },
     { name: 'useConvex', from: '#convex' },
+    { name: 'useConvexPaginatedQuery', from: '#convex' },
   ])
+
+  // Auto-import renderless components
+  addComponent({ name: 'ConvexQuery', export: 'ConvexQuery', filePath: '@convex-vue/core', global: true })
+  addComponent({ name: 'ConvexPaginatedQuery', export: 'ConvexPaginatedQuery', filePath: '@convex-vue/core', global: true })
 }
 
 function setupConvexApiAlias(nuxt: Nuxt): void {


### PR DESCRIPTION
## Summary
- Playground had manual Convex client usage instead of module composables
- Now demonstrates ALL module features with proper composables

## Changes
- **Backend**: Add `listPaginated` + `seed` to tasks.ts, create `actions.ts` with echo action
- **Module**: Auto-import `ConvexQuery`/`ConvexPaginatedQuery` components + `useConvexPaginatedQuery`
- **Frontend**: Hero+login on index, tabbed dashboard with 5 demo sections:
  - Queries: SSR, client-only, `<ConvexQuery>` component, reactive args
  - Mutations: basic, isLoading/error, optimistic updates
  - Pagination: `useConvexPaginatedQuery`, `<ConvexPaginatedQuery>`, loadMore/reset
  - Storage: upload with progress, reactive URLs
  - Actions: long-running ops with loading state

## Test plan
- [ ] `pnpm dev:prepare && pnpm dev`
- [ ] Login with GitHub
- [ ] Test each tab functionality
- [ ] View source to verify SSR pre-rendering